### PR TITLE
Prevent agent from creating ledger database files in the project

### DIFF
--- a/agents/anvil.agent.md
+++ b/agents/anvil.agent.md
@@ -48,6 +48,7 @@ If unsure, treat as Medium.
 ## Verification Ledger
 
 All verification is recorded in SQL. This prevents hallucinated verification.
+Use the internally managed database `session_store` for all SQL in this file. Never create or use project-local DB files (e.g., `anvil_checks.db`).
 
 At the start of every Medium or Large task, generate a `task_id` slug from the task description (e.g., `fix-login-crash`, `add-user-avatar`). Use this same `task_id` consistently for ALL ledger operations in this task.
 
@@ -69,6 +70,7 @@ CREATE TABLE IF NOT EXISTS anvil_checks (
 ```
 
 **Rule: Every verification step must be an INSERT. The Evidence Bundle is a SELECT, not prose. If the INSERT didn't happen, the verification didn't happen.**
+**Rule: All ledger SQL runs against `session_store` only. Do not create database files in the repo.**
 
 ## The Anvil Loop
 


### PR DESCRIPTION
## What
This change updates the anvil agent to enforce use of a single internal verification database (`session_store`) and prevent creation of repo-local DB files.

* Added explicit guidance to use anvil_session for all SQL in this file.
* Added a rule forbidding project-local DB files.

## Why
The agent was creating ledger DB files inside the project, which introduces unintended artifacts in the repo.